### PR TITLE
deps(global): remove unused packages

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { exec } from "child_process";
-import fs from "fs";
-import path from "path";
+import { exec } from "node:child_process";
+import fs from "node:fs";
+import path from "node;path";
 import exitHook from "exit-hook";
 
 function getProcessToRun() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,18 @@
 {
   "name": "run-singleton-cli",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "run-singleton-cli",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
-        "exit-hook": "^3.0.0",
-        "fs": "^0.0.1-security",
-        "path": "^0.12.7",
-        "url": "^0.11.0"
+        "exit-hook": "^3.0.0"
       },
       "bin": {
-        "run-singleton": "index.js"
+        "run-singleton": "index.mjs"
       },
       "devDependencies": {
         "concurrently": "^6.3.0",
@@ -247,11 +244,6 @@
         }
       }
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -269,11 +261,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -308,37 +295,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -419,23 +375,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
     },
     "node_modules/wait-on": {
       "version": "6.0.0",
@@ -680,11 +619,6 @@
       "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
       "dev": true
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -696,11 +630,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -732,30 +661,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -818,23 +723,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      }
     },
     "wait-on": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
   },
   "homepage": "https://github.com/guillemcordoba/singleton-cli#readme",
   "dependencies": {
-    "exit-hook": "^3.0.0",
-    "fs": "^0.0.1-security",
-    "path": "^0.12.7",
-    "url": "^0.11.0"
+    "exit-hook": "^3.0.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
Hi @guillemcordoba!

When trying to build Clutter, I ran into a problem with a strange package:

```bash
$ npm run build

> clutter-ui-vue@0.0.1 build
> vue-tsc --noEmit && vite build

vite v2.9.12 building for production...
✓ 107 modules transformed.
[vite:resolve] Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json.
error during build:
Error: Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "fs". The package may have incorrect main/module/exports specified in its package.json.
    at packageEntryFailure (/Users/jost/Desktop/holochain/clutter/node_modules/vite/dist/node/chunks/dep-8f5c9290.js:40945:11)
    at resolvePackageEntry (/Users/jost/Desktop/holochain/clutter/node_modules/vite/dist/node/chunks/dep-8f5c9290.js:40941:9)
    at tryNodeResolve (/Users/jost/Desktop/holochain/clutter/node_modules/vite/dist/node/chunks/dep-8f5c9290.js:40748:20)
    at Object.resolveId (/Users/jost/Desktop/holochain/clutter/node_modules/vite/dist/node/chunks/dep-8f5c9290.js:40556:28)
    at /Users/jost/Desktop/holochain/clutter/node_modules/rollup/dist/shared/rollup.js:22868:37
npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: clutter-ui-vue@0.0.1 
npm ERR!   at location: /Users/jost/Desktop/holochain/clutter/ui 
```

That package "fs" is part of `run-singleton-cli`, which in the package-lock.json looks like this

```json
"node_modules/run-singleton-cli": {
  "version": "0.0.5",
  "resolved": "https://registry.npmjs.org/run-singleton-cli/-/run-singleton-cli-0.0.5.tgz",
  "integrity": "sha512-g3KY3ViDELMRBS8w1kSniskzCU0/cKj4cV4SWVoaD/eG2MbtyE1Ny0egl8UMOGX7YWMtVNmy1vxFlIJ3tWSrTg==",
  "dev": true,
  "dependencies": {
    "exit-hook": "^3.0.0",
    **"fs": "^0.0.1-security",**
    "path": "^0.12.7",
    "url": "^0.11.0"
  },
  "bin": {
    "run-singleton": "index.mjs"
  }
},
```

That leads to this repo https://github.com/npm/security-holder.

**In short**, it seems to me that you added that and two other packages by accident to the singleton module. Here's a PR to remove them.

The test is very flaky on my machine, but I could get the expected result once 😁 :

```bash
$ npm t

> run-singleton-cli@0.0.5 test
> concurrently "npm run singleton" "npm run singleton"

[1] 
[1] > run-singleton-cli@0.0.5 singleton
[1] > node index.mjs "wait-on tcp:4000"
[1] 
[0] 
[0] > run-singleton-cli@0.0.5 singleton
[0] > node index.mjs "wait-on tcp:4000"
[0] 
[1] Singleton process already running, skipping
[1] npm run singleton exited with code 0
```